### PR TITLE
chg: usr: Update dane-discovery pin to v0.14.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name=PROJECT_NAME,
       url="https://github.com/valimail/{}".format(PROJECT_NAME),
       packages=[PROJECT_NAME],
       long_description=build_long_desc(),
-      install_requires=["dane_discovery==0.12", 
+      install_requires=["dane_discovery==0.14", 
                         "jwcrypto~=0.7"],
       classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This update includes changes to the pattern used for forming
the PKIXCD CA certificate URL.

Close #11